### PR TITLE
updated hdfs support for qhub-onprem

### DIFF
--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -144,3 +144,10 @@ backup:
   environment:
     RESTIC_REPOSITORY: ...
     RESTIC_PASSWORD: ...
+
+hadoop:
+  enabled: true
+  version: "3.3.0"
+  env_path: ["JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64","HADOOP_HOME=/opt/hadoop",'HADOOP_INSTALL=\$HADOOP_HOME','HADOOP_MAPRED_HOME=\$HADOOP_HOME','HADOOP_COMMON_HOME=\$HADOOP_HOME','HADOOP_HDFS_HOME=\$HADOOP_HOME','YARN_HOME=\$HADOOP_HOME','HADOOP_COMMON_LIB_NATIVE_DIR=\$HADOOP_HOME/lib/native','PATH=\$PATH:\$HADOOP_HOME/sbin:\$HADOOP_HOME/bin',"HADOOP_OPTS='-Djava.library.path=/opt/hadoop-3.3.0/lib/native'","HADOOP_OPTIONAL_TOOLS=hadoop-azure",'ARROW_LIBHDFS_DIR=\$HADOOP_COMMON_LIB_NATIVE_DIR','CLASSPATH=\`\$HADOOP_HOME/bin/hdfs classpath --glob\`']
+  hadoopkey: ""
+  account_name: ""

--- a/tasks/hadoop.yaml
+++ b/tasks/hadoop.yaml
@@ -1,0 +1,55 @@
+---
+ #- name: install adlfs
+ #  shell: "{{ miniforge.home }}/bin/conda install --quiet --yes adlfs -c conda-forge"
+ #  args:
+ #    executable: /bin/bash
+ #  become: True
+
+ - name: install open sdk
+   apt:
+     name: openjdk-11-jre-headless
+     state: present
+   become: True
+ 
+ - name: Remove hadoop folder
+   shell: "rm -rf /opt/hadoop"
+   become: True
+
+ - name: Download and extract hadoop
+   ansible.builtin.unarchive:
+     src:  "https://mirrors.sonic.net/apache/hadoop/common/hadoop-{{ hadoop.version }}/hadoop-{{ hadoop.version }}.tar.gz"
+     dest:  /opt/
+     remote_src: yes
+     owner: root
+   become: True
+
+ - name: Move folder to hadoop-{{ hadoop.version }} to hadoop
+   shell: "mv /opt/hadoop-{{ hadoop.version }} /opt/hadoop && chmod 777 /opt/hadoop"
+   become: True
+
+ - name: Export environment variables into /etc/bash.bashrc
+   shell: "echo \"export {{item}}\" >> /etc/bash.bashrc"
+   with_items:
+      - "{{ hadoop.env_path }}"
+   become: True
+
+ - name: Adding support and credentials for hadoop
+   blockinfile:
+     dest: /opt/hadoop/etc/hadoop/core-site.xml
+     marker: "#source file additions"
+     insertafter: <configuration>
+     block: |
+       <property>
+          <name>fs.azure.account.auth.type.{{ hadoop.account_name }}.dfs.core.windows.net</name>
+          <value>SharedKey</value>
+          <description>
+          </description>
+       </property>
+       <property>
+          <name>fs.azure.account.key.{{ hadoop.account_name }}.dfs.core.windows.net</name>
+          <value>{{ hadoop.hadoopkey }}</value>
+          <description>
+              The secret password. Never share these.
+          </description>
+       </property>
+   become: True


### PR DESCRIPTION
Added hdfs support for qhub.
- An Ansible script is created to install openjdk11.
- Remove the current hadoop installation.
- Download and extract haddop 3.x version
- Rename & move the installation under /opt folder structure.
- Add the environment variables to .bashrc.
- Add configuration properties to enable azure auth into core-site.xml file.
- All values have been stored within group_vars/all.yaml file.
- Values are used in hadoop.yaml file under tasks folder.