### PR TITLE
Remove redundant `dask_gateway_client_enabled` ansible var

### DIFF
--- a/roles/dask_gateway/defaults/main.yml
+++ b/roles/dask_gateway/defaults/main.yml
@@ -5,8 +5,6 @@ dask_gateway_scheduler_external_port: "8786"
 dask_gateway_client_enabled: true
 dask_gateway_environment: "environments/dask-gateway.yaml"
 
-dask_gateway_client_enabled: true
-
 # role: miniforge
 miniforge_home: "/opt/conda"
 


### PR DESCRIPTION
The same var/value is defined a couple lines above.

This gets rid of the following warning which appears at the start of the Ansible playbook run:

```
[WARNING]: While constructing a mapping from .../qhub-hpc/roles/dask_gateway/defaults/main.yml, line 1, column 1, found a duplicate dict key
(dask_gateway_client_enabled). Using last defined value only.
```

fyi @costrouc 