### PR TITLE
Update requirements.yaml to pin community.general ansible version

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -2,4 +2,5 @@
 collections:
   - name: community.mysql
   - name: community.general
+    version: 4.2.0
   - name: ansible.posix


### PR DESCRIPTION
It seems the latest version of `community.general` (4.5.0) which came out 2 days ago doesn't work properly for the keycloak ansible tasks:

```
fatal: [hpc-master-node]: FAILED! => {"reason": "couldn't resolve module/action 'community.general.keycloak_realm'. This often indicates a misspelling, missing collection, or incorrect module path.\n\nThe error appears to be in '.../qhub-hpc/roles/keycloak/tasks/realm.yaml': line 2, column 4, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n---\n - name: Create or update Keycloak realm\n   ^ here\n"}
```

After changing `community.general` to 4.2.0 with this branch, which is the version number listed here https://docs.ansible.com/ansible/latest/collections/community/general/keycloak_realm_module.html (and also here https://docs.ansible.com/ansible/latest/collections/community/general/), it now works. So this will need to be pinned to avoid the above problem, at least for now.

fyi @costrouc 