### PR TITLE
Don't print passwords while running Ansible playbook

### DIFF
--- a/playbook.yaml
+++ b/playbook.yaml
@@ -48,7 +48,7 @@
 
      - name: Keycloak administration credentials
        ansible.builtin.debug:
-         msg: "Keycloak administration username={{ keycloak_admin_username }} password={{ keycloak_admin_password }} via https://{{ traefik_domain | default(hostvars[groups['hpc-master'][0]].ansible_host) }}/auth/admin/"
+         msg: "Keycloak administration username={{ keycloak_admin_username }} via https://{{ traefik_domain | default(hostvars[groups['hpc-master'][0]].ansible_host) }}/auth/admin/"
 
      - name: Accessing cluster
        ansible.builtin.debug:

--- a/roles/cifs/tasks/client.yaml
+++ b/roles/cifs/tasks/client.yaml
@@ -13,6 +13,7 @@
      port: 445
      timeout: 600
    with_items: "{{ samba_client_mounts }}"
+   no_log: True  # Avoid logging user creds
 
  - name: Ensure samba mounted directories exist
    become: true
@@ -20,6 +21,7 @@
      path: "{{ item.path }}"
      state: directory
    with_items: "{{ samba_client_mounts }}"
+   no_log: True  # Avoid logging user creds
 
  - name: Ensure samba credentials directory exists
    become: true
@@ -48,6 +50,7 @@
      group: root
      mode: 0600
    with_items: "{{ samba_client_mounts }}"
+   no_log: True  # Avoid logging user creds
 
  - name: Add fstab entries for nfs mounts
    become: true
@@ -58,3 +61,4 @@
      state: mounted
      fstype: cifs
    with_items: "{{ samba_client_mounts }}"
+   no_log: True  # Avoid logging user creds

--- a/roles/mysql/tasks/mysql.yaml
+++ b/roles/mysql/tasks/mysql.yaml
@@ -37,3 +37,4 @@
      priv: "{{ item.privileges }}"
      state: present
    with_items: "{{ mysql_users }}"
+   no_log: True  # Avoid logging user creds


### PR DESCRIPTION
Without this, full plaintext passwords are shown for any cifs mounts, for Keycloak, and for mysql. This disables that from being printed by following Ansible's suggestion here: https://docs.ansible.com/ansible/latest/reference_appendices/logging.html#protecting-sensitive-data-with-no-log
