### PR TITLE
Add concurrency setting to Conda Store config file

### DIFF
--- a/roles/conda_store/templates/conda_store_config.py
+++ b/roles/conda_store/templates/conda_store_config.py
@@ -108,3 +108,4 @@ c.CondaStoreServer.authentication_class = KeyCloakAuthentication
 # ==================================
 c.CondaStoreWorker.log_level = logging.INFO
 c.CondaStoreWorker.watch_paths = ["/opt/environments"]
+c.CondaStoreWorker.concurrency = 4


### PR DESCRIPTION
Similar to https://github.com/Quansight/conda-store/pull/254,
conda-store-worker logs were showing errors about `concurrency` not
being set:

```
Traceback (most recent call last):
  File "/opt/conda/envs/conda-store/lib/python3.10/site-packages/traitlets/traitlets.py", line 537, in get
    value = obj._trait_values[self.name]
KeyError: 'concurrency'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/opt/conda/envs/conda-store/bin/conda-store-worker", line 10, in <module>
    sys.exit(main())
  File "/opt/conda/envs/conda-store/lib/python3.10/site-packages/traitlets/config/application.py", line 846, in launch_instance
    app.start()
  File "/opt/conda/envs/conda-store/lib/python3.10/site-packages/conda_store_server/worker/app.py", line 68, in start
    if self.concurrency:
  File "/opt/conda/envs/conda-store/lib/python3.10/site-packages/traitlets/traitlets.py", line 577, in __get__
    return self.get(obj, cls)
  File "/opt/conda/envs/conda-store/lib/python3.10/site-packages/traitlets/traitlets.py", line 550, in get
    value = self._validate(obj, default)
  File "/opt/conda/envs/conda-store/lib/python3.10/site-packages/traitlets/traitlets.py", line 612, in _validate
    value = self.validate(obj, value)
  File "/opt/conda/envs/conda-store/lib/python3.10/site-packages/traitlets/traitlets.py", line 2046, in validate
    self.error(obj, value)
  File "/opt/conda/envs/conda-store/lib/python3.10/site-packages/traitlets/traitlets.py", line 692, in error
    raise TraitError(e)
traitlets.traitlets.TraitError: The 'concurrency' trait of a CondaStoreWorker instance expected an int, not the NoneType None.
```

fyi @costrouc 