### PR TITLE
Don't set `force: no` for copy_files task (to allow file updates)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -222,8 +222,7 @@ The owner, group, and mode fields are optional. See
 https://docs.ansible.com/ansible/latest/collections/ansible/builtin/copy_module.html#id2
 for more detail about each field.
 
-Files copied in this way will not overwrite existing files.  Also,
-remember that the home directory of users is a network file system so
+Remember that the home directory of users is a network file system so
 it would only be necessary to copy files in the user directories into
 a single node.
 

--- a/tasks/copy_files.yaml
+++ b/tasks/copy_files.yaml
@@ -8,6 +8,5 @@
      group: "{{ item.group | default(omit) }}"
      mode: "{{ item.mode | default(omit) }}"
      directory_mode: "{{ item.directory_mode | default(omit) }}"
-     force: no  # only copy files over if they don't exist on destination
    when: (vars['copy_files_' + myhost]) is defined
    loop: "{{ vars['copy_files_' + myhost] }}"


### PR DESCRIPTION
With `force: no`, files will only ever be copied once, and any changes to those files will never be copied to the remote host(s) again. This is not the default behavior with the ansible copy_module https://docs.ansible.com/ansible/latest/collections/ansible/builtin/copy_module.html#id2, and makes this feature much less useful/practical. If it's necessary for some more obscure use-case, I could see making `force` a configurable param in the `copy_files_*` items, but it doesn't seem necessary to me or for our known use-cases.

@Adam-D-Lewis @costrouc 
