### PR TITLE
Configurable user options form

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -150,6 +150,12 @@ jupyterhub_custom:
       JUPYTERHUB_SINGLEUSER_APP: notebook.notebookapp.NotebookApp
 ```
 
+### Turn off resource selection user options form
+The resource selection options form allows users to choose the cpu, memory, and partition on which to run their user server.  This feature is enabled by default, but can be disabled as shown below.
+```yaml
+jupyterhub_qhub_options_form: false
+```
+
 ### Services
 
 Additional services can be added to the `jupyterhub_services`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -151,7 +151,7 @@ jupyterhub_custom:
 ```
 
 ### Turn off resource selection user options form
-The resource selection options form allows users to choose the cpu, memory, and partition on which to run their user server.  This feature is enabled by default, but can be disabled as shown below.
+The resource selection options form allows users to choose the cpu, memory, and partition on which to run their user server.  This feature is enabled by default, but can be disabled as shown below.  This controls the option form for both the user and CDSDashboards.
 ```yaml
 jupyterhub_qhub_options_form: false
 ```

--- a/inventory.template/group_vars/hpc-master.yaml
+++ b/inventory.template/group_vars/hpc-master.yaml
@@ -2,6 +2,7 @@ dask_gateway_enabled: true
 firewall_enabled: true
 grafana_enabled: true
 jupyterhub_enabled: true
+jupyterhub_qhub_options_form: true
 jupyterhub_ssh_enabled: true
 keycloak_enabled: true
 miniforge_enabled: true

--- a/roles/jupyterhub/defaults/main.yml
+++ b/roles/jupyterhub/defaults/main.yml
@@ -17,7 +17,7 @@ jupyterhub_lab_environment: "environments/jupyterlab.yaml"
 jupyterhub_dashboard_environment: "environments/dashboards.yaml"
 jupyterhub_client_id: "jupyterhub"
 jupyterhub_client_secret: "SUPERSECRETPASSWORDJUPYTERHUB"
-jupyterhub_qhub_options_form: false
+jupyterhub_qhub_options_form: true
 
 jupyterhub_config:
   spawner:

--- a/roles/jupyterhub/defaults/main.yml
+++ b/roles/jupyterhub/defaults/main.yml
@@ -17,6 +17,7 @@ jupyterhub_lab_environment: "environments/jupyterlab.yaml"
 jupyterhub_dashboard_environment: "environments/dashboards.yaml"
 jupyterhub_client_id: "jupyterhub"
 jupyterhub_client_secret: "SUPERSECRETPASSWORDJUPYTERHUB"
+jupyterhub_qhub_options_form: false
 
 jupyterhub_config:
   spawner:

--- a/roles/jupyterhub/templates/jupyterhub_config.py
+++ b/roles/jupyterhub/templates/jupyterhub_config.py
@@ -131,6 +131,7 @@ class QHubHPCSpawnerBase(SlurmSpawner):
         help="Conda environment prefix to launch jupyterlab"
     ).tag(config=True)
 
+{% if jupyterhub_qhub_options_form %}
   # data from form submission is {key: [value]}
   # we need to convert the formdata to a key value dict
   def options_from_form(self, data):
@@ -188,7 +189,7 @@ class QHubHPCSpawnerBase(SlurmSpawner):
 
     # Display full form including conda env dropdown
     return ''.join([self.main_options_form, self.conda_options_form])
-
+{% endif %}
 
 {% if cdsdashboards_enabled %}
 # -------------------- Specify Dashboard Instance Size --------------------


### PR DESCRIPTION
The resource selection options form allows users to choose the cpu, memory, and partition on which to run their user server.  This feature can now be disabled with this PR.  Disabling this feature will disable for both users and dashboards.

Closes #109 