### PR TITLE
Allow multiple services traffic through firewall

### DIFF
--- a/roles/openldap/tasks/openldap.yaml
+++ b/roles/openldap/tasks/openldap.yaml
@@ -57,3 +57,10 @@
      objectClass:
        - top
        - domain
+
+ - name: Allow OpenLDAP through firewall
+   become: true
+   community.general.ufw:
+     rule: allow
+     name: OpenLDAP LDAP
+   when: firewall_enabled

--- a/roles/prometheus/tasks/node_exporter.yml
+++ b/roles/prometheus/tasks/node_exporter.yml
@@ -88,3 +88,11 @@
      enabled: true
      state: started
    when: _node_exporter_service.changed
+
+ - name: Allow node_exporter through firewall
+   become: true
+   community.general.ufw:
+     rule: allow
+     port: "{{ node_exporter_port }}"
+     proto: tcp
+   when: firewall_enabled

--- a/roles/slurm/tasks/slurmctld.yaml
+++ b/roles/slurm/tasks/slurmctld.yaml
@@ -69,3 +69,11 @@
      enabled: true
      state: restarted
    when: _slurm_config.changed or _slurm_cgroup_config.changed or _slurmctld_service.changed or _slurmctld_package.changed
+
+ - name: Allow slurmctld through firewall
+   become: true
+   community.general.ufw:
+     rule: allow
+     port: "{{ slurm_config.SlurmctldPort }}"
+     proto: tcp
+   when: firewall_enabled

--- a/roles/slurm/tasks/slurmd.yaml
+++ b/roles/slurm/tasks/slurmd.yaml
@@ -72,3 +72,11 @@
      enabled: true
      state: restarted
    when: _slurm_config.changed or _slurm_cgroup_config.changed or _slurmd_service.changed or _slurmd_package.changed
+
+ - name: Allow slurmd through firewall
+   become: true
+   community.general.ufw:
+     rule: allow
+     port: "{{ slurm_config.SlurmdPort }}"
+     proto: tcp
+   when: firewall_enabled


### PR DESCRIPTION
Supports #111

All external LDAP traffic was being blocked by UFW because it wasn't
whitelisted, making anything related to auth (like SSH and sudo) very
slow or just fail after waiting.

nslcd logs before and after deploying this change:

```
hpc-worker-02 nslcd[2653]: [517796] <group/member="ewang"> no available LDAP server found: Server is unavailable: Co
nnection timed out
(deploy)
hpc-worker-02 nslcd[2653]: [014acb] <group/member="ewang"> connected to LDAP server ldap://hpc-master-node:389
```