### PR TITLE
Fix typos: "Slrum"->"Slurm"

### DIFF
--- a/roles/grafana/files/dashboards/slurm_exporter.json
+++ b/roles/grafana/files/dashboards/slurm_exporter.json
@@ -678,7 +678,7 @@
         "#d44a3a"
       ],
       "datasource": "Prometheus",
-      "description": "The agent mechanism helps to control communication between the Slrum daemons and the controller for a best effort.",
+      "description": "The agent mechanism helps to control communication between the Slurm daemons and the controller for a best effort.",
       "fieldConfig": {
         "defaults": {
           "custom": {}

--- a/roles/slurm/tasks/slurmctld.yaml
+++ b/roles/slurm/tasks/slurmctld.yaml
@@ -31,7 +31,7 @@
    copy:
      content: |
        [Unit]
-       Description=Slrum controller daemon
+       Description=Slurm controller daemon
        After=network.target munge.service
        ConditionPathExists=/etc/slurm-llnl/slurm.conf
 

--- a/roles/slurm/tasks/slurmd.yaml
+++ b/roles/slurm/tasks/slurmd.yaml
@@ -31,7 +31,7 @@
    copy:
      content: |
        [Unit]
-       Description=Slrum node daemon
+       Description=Slurm node daemon
        After=network.target munge.service remote-fs.target
        ConditionPathExists=/etc/slurm-llnl/slurm.conf
 

--- a/roles/slurm/tasks/slurmdbd.yaml
+++ b/roles/slurm/tasks/slurmdbd.yaml
@@ -32,7 +32,7 @@
    copy:
      content: |
        [Unit]
-       Description=Slrum DBD accounting daemon
+       Description=Slurm DBD accounting daemon
        After=network.target munge.service
        ConditionPathExists=/etc/slurm-llnl/slurmdbd.conf
 


### PR DESCRIPTION
These typos show up in statuses and logs:

```
$ systemctl status slurmd.service
● slurmd.service - Slrum node daemon

$ journalctl -u slurmd.service
systemd[1]: Started Slrum node daemon.
systemd[1]: Stopping Slrum node daemon...
```