### PR TITLE
Use batchspawner official release (1.1.0)

### DIFF
--- a/roles/jupyterhub/templates/environments/dashboards.yaml
+++ b/roles/jupyterhub/templates/environments/dashboards.yaml
@@ -18,5 +18,4 @@ dependencies:
   - dash >= 1.19
   - cdsdashboards-singleuser
   - pip:
-      # batchspawner latest slurm fixes
-      - https://github.com/jupyterhub/batchspawner/archive/129951ad11e3049567b94adb8c9725dc22225a1a.tar.gz
+      - batchspawner==1.1.0

--- a/roles/jupyterhub/templates/environments/jupyterhub.yaml
+++ b/roles/jupyterhub/templates/environments/jupyterhub.yaml
@@ -13,7 +13,6 @@ dependencies:
       - jupyterhub-traefik-proxy
       # jupyterhub-ssh has not made a release yet
       - git+https://github.com/yuvipanda/jupyterhub-ssh.git
-      # batchspawner latest slurm fixes
-      - https://github.com/jupyterhub/batchspawner/archive/129951ad11e3049567b94adb8c9725dc22225a1a.tar.gz
+      - batchspawner==1.1.0
       # cdsdashboards
       - cdsdashboards==0.5.0b2

--- a/roles/jupyterhub/templates/environments/jupyterlab.yaml
+++ b/roles/jupyterhub/templates/environments/jupyterlab.yaml
@@ -20,5 +20,4 @@ dependencies:
       - https://github.com/mamba-org/gator/archive/conda-store-integration.tar.gz
       # vscode jupyterlab launcher
       - git+https://github.com/betatim/vscode-binder
-      # batchspawner latest slurm fixes
-      - https://github.com/jupyterhub/batchspawner/archive/1decdf259a25c8e33e90de7a5817da11a92c0326.tar.gz
+      - batchspawner==1.1.0


### PR DESCRIPTION
For two of these environment files, it referenced commit https://github.com/jupyterhub/batchspawner/commit/129951ad11e3049567b94adb8c9725dc22225a1a, which (as you can see at the above link) was incorporated in the v1.1.0 release since then. The last environment file `jupyterlab.yaml` referenced a slightly newer commit (https://github.com/jupyterhub/batchspawner/commit/1decdf259a25c8e33e90de7a5817da11a92c0326) which just made some internal maintenance changes (like running an auto-formatter) on top of the 1.1.0 version, so this makes everything pin to the latest official release for consistency/simplicity.

For what it's worth, in our openhpc deployment, we changed from the 129951ad11e3049567b94adb8c9725dc22225a1a commit to v1.1.0 successfully several months ago and haven't had issues. I have also tested qhub-hpc deployment with this change and saw that the environments were updated as expected and servers were still able to be spawned working.