### PR TITLE
Fix custom Traefik TLS certificate logic (register missing vars), and add `remote_src` option

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -292,7 +292,10 @@ traefik_tls_key: /path/to/MyKey.key
 
 For testing out this optional it is easy to generate your own
 self-signed certificate. Substitute all of the values for values that
-fit your use case.
+fit your use case. If you need to copy the certificate and/or key from a
+location on the remote server (as opposed to a local file on the Ansible
+host), you can also add `traefik_tls_certificate_remote_src: true` and
+`traefik_tls_key_remote_src: true`, respectively.
 
 ```shell
 export QHUB_HPC_DOMAIN=example.com

--- a/roles/traefik/tasks/traefik.yaml
+++ b/roles/traefik/tasks/traefik.yaml
@@ -89,6 +89,7 @@
    copy:
      src: "{{ traefik_tls_certificate }}"
      dest: /etc/traefik/certs/{{ traefik_tls_certificate | basename }}
+     remote_src: "{{ traefik_tls_certificate_remote_src | default(false) }}"
      mode: '444'
      owner: traefik
      group: traefik
@@ -102,6 +103,7 @@
    copy:
      src: "{{ traefik_tls_key }}"
      dest: /etc/traefik/certs/{{ traefik_tls_key | basename }}
+     remote_src: "{{ traefik_tls_key_remote_src | default(false) }}"
      mode: '0400'
      owner: traefik
      group: traefik

--- a/roles/traefik/tasks/traefik.yaml
+++ b/roles/traefik/tasks/traefik.yaml
@@ -94,6 +94,7 @@
      group: traefik
    when: traefik_tls_certificate is defined
    notify: restart services traefik
+   register: _traefik_tls_certificate
 
 
  - name: Copy TLS key if provided
@@ -106,6 +107,7 @@
      group: traefik
    when: traefik_tls_key is defined
    notify: restart services traefik
+   register: _traefik_tls_key
 
 
  - name: Copy traefik configuration


### PR DESCRIPTION
Two changes:

- [bug fix] Register the TLS cert and key Ansible copy results
    - These variables are referenced in https://github.com/Quansight/qhub-hpc/blob/37a5d431ae2613d83eee7003a6d2599dea951208/roles/traefik/templates/traefik_dynamic.yaml#L1-L13 but were not being registered/created. This fixes that.
- Add option to use remote source for TLS cert/key files
    - Our cert and key are stored on our remote machine, so we need the option to use a `remote_src` when copying the files (rather than use a file local to the host running Ansible).

I've tested this branch locally, and it worked to serve the cert. Without the bug fix mentioned above, I encountered the following:

```
TASK [traefik : Copy traefik dynamic configuration] ********************************************************************************************************
Tuesday 29 March 2022  19:20:29 -0700 (0:00:01.097)       0:01:05.133 *********
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.errors.AnsibleUndefinedVariable: '_traefik_tls_certificate' is undefined
fatal: [hpc-master-node]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: '_traefik_tls_certificate' is undefined"}
```

Please take a look @Adam-D-Lewis @costrouc 