### PR TITLE
Fix worker node servers getting killed after JuptyerHub restart

### DIFF
--- a/roles/jupyterhub/templates/jupyterhub_config.py
+++ b/roles/jupyterhub/templates/jupyterhub_config.py
@@ -120,11 +120,11 @@ c.JupyterHub.authenticator_class = QHubAuthenticator
 
 class QHubHPCSpawnerBase(SlurmSpawner):
   async def poll(self):
-      # on server restart the port appears to change when poll() is called
-      # on the server.port object. This shim ensures that port is preserved
-      port = self.server.port
+      # on server restart the IP and port appears to change when poll() is called
+      # on the server object. This shim ensures that those are preserved
+      ip, port = self.server.ip, self.server.port
       value = await super().poll()
-      self.server.port = port
+      self.server.ip, self.server.port = ip, port
       return value
 
   req_conda_environment_prefix = Unicode('',


### PR DESCRIPTION
Follow-up to #106 and fixes #104 (again)

We discovered in the JupyterHub logs that it was trying to contact the
master node for jobs scheduled on worker nodes which was incorrect and
led to them getting killed:

```
Notebook server job 157 started at hpc-worker-02:52649
(JupyterHub restart)
server never showed up at http://hpc-master-node:52649
```

This fixes the problem by preserving `self.server.ip` similar to
`self.server.port` in `QHubHPCSpawnerBase.poll()`.