### PR TITLE
Only create symlink /share if /home/share exists

### DIFF
--- a/roles/jupyterhub/templates/jupyterhub_config.py
+++ b/roles/jupyterhub/templates/jupyterhub_config.py
@@ -240,8 +240,8 @@ c.QHubHPCSpawner.req_memory = '1' # GB
 c.QHubHPCSpawner.req_nprocs = '1'
 c.QHubHPCSpawner.req_conda_environment_prefix = '{{ miniforge_home }}/envs/{{ jupyterhub_lab_environment | basename | splitext | first }}'
 c.QHubHPCSpawner.req_prologue = '''
-# ensure user has link to shared directory
-if [ ! -L "$HOME/share" ]; then
+# ensure user has link to the shared directory, if it exists
+if [ -d "/home/share" ] && [ ! -L "$HOME/share" ]; then
   ln -s /home/share "$HOME/share"
 fi
 


### PR DESCRIPTION
We never added a `/home/share` and don't intend to create one, so this makes the existing prologue work without issue for our scenario. Without this, the prologue always creates a "dead" symlink that points to a non-existent directory. That path also appears broken in the JupyterHub notebook interface, where if clicked it leads to a 404:

<img width="570" alt="image" src="https://user-images.githubusercontent.com/1647130/164349557-8b14af15-e681-4621-9acc-60dd597688d4.png">

Confirmed after deploying this that the `$HOME/share` directory was not created when launching a new notebook server.

PTAL @costrouc @Adam-D-Lewis 