### PR TITLE
Add variables for Grafana version and additional config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -319,6 +319,29 @@ prometheus_additional_scrape_configs:
         - 'example.com:9100'
 ```
 
+## Grafana
+
+### Specifying version
+
+The latest Grafana version will be installed by default but a specific or minimum
+version can be specified with `grafana_version`:
+
+```yaml
+grafana_version: "=9.0.0"  # Pin to 9.0.0
+grafana_version: ">=9.0.0"  # Install latest version only if current version is <9.0.0
+```
+
+## Adding additional configuration
+
+You can add additional configuration to the `grafana.ini` file using
+`grafana_additional_config`:
+
+```yaml
+grafana_additional_config: |
+  [users]
+  viewers_can_edit = true  # Allow Viewers to edit but not save dashboards
+```
+
 ## Backups
 
 Backups are performed in QHub HPC via [restic](https://restic.net/)

--- a/roles/grafana/defaults/main.yml
+++ b/roles/grafana/defaults/main.yml
@@ -10,6 +10,8 @@ grafana_dashboards:
   - traefik
   - conda_store
   - keycloak
+grafana_version: ""
+grafana_additional_config: ""
 
 # role: prometheus
 prometheus_port: "9090"

--- a/roles/grafana/tasks/grafana.yaml
+++ b/roles/grafana/tasks/grafana.yaml
@@ -13,8 +13,8 @@
  - name: Install grafana
    become: true
    apt:
-     name: grafana
-     state: latest
+     name: grafana{{ grafana_version }}
+     state: "{% if grafana_version %}present{% else %}latest{% endif %}"
      cache_valid_time: 3600
 
  - name: Create keycloak client for grafana
@@ -154,6 +154,11 @@
        tls_skip_verify_insecure = true
        login_attribute_path: preferred_username
        role_attribute_path: "contains(roles[*], 'grafana_admin') && 'Admin' || contains(roles[*], 'grafana_developer') && 'Editor' || contains(roles[*], 'grafana_viewer') || 'Viewer'"
+
+       [dashboards]
+       min_refresh_interval = 1s
+
+       {{ grafana_additional_config }}
      dest: /etc/grafana/grafana.ini
      owner: root
      group: grafana


### PR DESCRIPTION
We'd like to pin the Grafana version so that it isn't unexpectedly upgraded during a deploy and add some additional configuration that may not be desirable for everyone (like `viewers_can_edit`). This does add `min_refresh_interval = 1s` though to the default config since that seems reasonable to set for everyone (the Grafana default is 5s which doesn't make sense to me) .

PTAL @costrouc @Adam-D-Lewis 
cc @sjdemartini 