### PR TITLE
Fix bug that sets all users to have homedir of the newly logged-in user

### DIFF
--- a/roles/jupyterhub/templates/jupyterhub_config.py
+++ b/roles/jupyterhub/templates/jupyterhub_config.py
@@ -94,7 +94,7 @@ def sync_users(username, min_uid=1_000_000, max_uid=1_000_000_000):
 
         payload = user
         payload['attributes']['jupyterhubCheck'] = 'true'
-        payload['attributes']['homeDirectory'] = f'/home/{username}'
+        payload['attributes']['homeDirectory'] = f"/home/{user['username']}"
 
         initial_uid = (hash(user['username']) % (max_uid - min_uid)) + min_uid
         while initial_uid in current_uids:


### PR DESCRIPTION
This code tries to "sync" all users back to Keycloak whenever any *new* user logs in via JupyterHub. However, it mistakenly sets *every* user who exists in Keycloak (who wasn't previously synced) as having the new user's home directory, which leads to problems for those users should they try to spawn notebook servers, etc.

This caught us badly in our official deployment (we're updating all user's homedirs manually in Keycloak now). Haven't been able to test this new code change directly since all users have accounts at this point, but I believe it's what was intended here.