### PR TITLE
Add variable for Grafana provisioned dashboards folder

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -321,6 +321,17 @@ prometheus_additional_scrape_configs:
 
 ## Grafana
 
+### Changing provisioned dashboards folder
+
+All provisioned dashboards in the `grafana_dashboards` variable will be added to the
+"General" folder by default. "General" is a special folder where anyone can add
+dashboards and can't be restricted so if you wish to separate provisioned dashboards you
+can set `grafana_dashboards_folder`:
+
+```yaml
+grafana_dashboards_folder: "Official"
+```
+
 ### Specifying version
 
 The latest Grafana version will be installed by default but a specific or minimum
@@ -331,7 +342,7 @@ grafana_version: "=9.0.0"  # Pin to 9.0.0
 grafana_version: ">=9.0.0"  # Install latest version only if current version is <9.0.0
 ```
 
-## Adding additional configuration
+### Adding additional configuration
 
 You can add additional configuration to the `grafana.ini` file using
 `grafana_additional_config`:

--- a/roles/grafana/defaults/main.yml
+++ b/roles/grafana/defaults/main.yml
@@ -10,6 +10,7 @@ grafana_dashboards:
   - traefik
   - conda_store
   - keycloak
+grafana_dashboards_folder: ""
 grafana_version: ""
 grafana_additional_config: ""
 

--- a/roles/grafana/templates/grafana-dashboards.yaml
+++ b/roles/grafana/templates/grafana-dashboards.yaml
@@ -7,7 +7,7 @@ apiVersion: 1
 providers:
  - name: 'Prometheus'
    orgId: 1
-   folder: ''
+   folder: '{{ grafana_dashboards_folder }}'
    type: file
    disableDeletion: false
    editable: true


### PR DESCRIPTION
Currently all provisioned dashboards are added to the "General" folder
which is a special location where anyone can add dashboards and can't be
restricted. That makes it difficult to distinguish them from other
dashboards so this adds a variable to optionally change the folder.

PTAL @costrouc @Adam-D-Lewis 
cc @sjdemartini 