### PR TITLE
Update Grafana APT repository URL

### DIFF
--- a/roles/grafana/tasks/grafana.yaml
+++ b/roles/grafana/tasks/grafana.yaml
@@ -8,7 +8,7 @@
  - name: Add apt repository for grafana
    become: true
    apt_repository:
-     repo: "deb https://packages.grafana.com/oss/deb stable main"
+     repo: "deb https://apt.grafana.com stable main"
 
  - name: Install grafana
    become: true


### PR DESCRIPTION
Grafana recently updated their APT repository which caused the `Ensure apt packages are installed` task to fail:
https://grafana.com/docs/grafana/latest/setup-grafana/installation/debian/#repository-migration-november-8th-2022

```
fatal: [hpc-master-node]: FAILED! => {"changed": false, "msg": "Failed to update apt cache: W:This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details., E:Repository 'https://packages.grafana.com/oss/deb stable InRelease' changed its 'Origin' value from 'grafana stable' to '. stable', E:Repository 'https://packages.grafana.com/oss/deb stable InRelease' changed its 'Label' value from 'grafana stable' to '. stable'"}
```

Grafana says the old URLs will still work fine though and subsequent deploys did work so it doesn't seem to be an issue now, but figured we should be using the new URL anyway.